### PR TITLE
Five-fig modifications

### DIFF
--- a/src/icebreaker/cli/ib_5fig.py
+++ b/src/icebreaker/cli/ib_5fig.py
@@ -44,7 +44,7 @@ def run_job(project_dir, job_dir, args_list):
         if os.path.split(micrograph)[-1] not in done_mics:
             os.link(os.path.join(project_dir, micrograph),
                     os.path.join('IB_input',
-                    os.path.split(micrograph)[-1]))
+                    micrograph))
 
     five_figures.main('IB_input')
     print('Done five figures')

--- a/src/icebreaker/five_figures.py
+++ b/src/icebreaker/five_figures.py
@@ -11,31 +11,32 @@ import seaborn as sns
 def main(mic_path):
 	orig_stdout = sys.stdout
 	indir = mic_path
-	f = open('five_figs_test.csv','w')
-	sys.stdout = f
-	files = []
-	for filename in os.listdir(indir):
-		if (filename.endswith(".mrc")):
-			finalpath = os.path.join(indir,filename)
-			files.append(finalpath)
-		else:
-			continue
-#files = files.sort()
-	files = sorted(files)
-	vector_data = []
-	r=10000
-
-	print('path,','min,','q1,','q2=median,','q3,','max')
-	for img_path in files:
-		with mrcfile.open(img_path, 'r', permissive=True) as mrc:
-			img = mrc.data
-			if(np.isnan(np.sum(img))):
-				continue
+	with open('five_figs_test.csv','w') as f:
+		files = []
+		for filename in os.listdir(indir):
+			if (filename.endswith(".mrc")):
+				finalpath = os.path.join(indir, filename)
+				files.append(finalpath)
 			else:
-				print(img_path[:-4]+',',str(int(np.min(img)*r))+',',str(int(np.quantile(img,0.25)*r))+',',str(int(np.median(img)*r))+',',str(int(np.quantile(img,0.75)*r))+',',int(np.max(img)*r))
+				continue
+		# files = files.sort()
+		files = sorted(files)
+		vector_data = []
+		r = 10000
 
-	sys.stdout = orig_stdout
+		f.write('path,min,q1,q2=median,q3,max')
+		for img_path in files:
+			with mrcfile.open(img_path, 'r', permissive=True) as mrc:
+				img = mrc.data
+				if (np.isnan(np.sum(img))):
+					continue
+				else:
+					data_line = img_path[:-4] + ',', str(int(np.min(img) * r)) + ',', str(int(np.quantile(img, 0.25) * r)) + ',',
+					str(int(np.median(img) * r)) + ',', str(int(np.quantile(img, 0.75) * r)) + ',',
+					int(np.max(img) * r)
+					f.write(data_line)
 	f.close()
+		
 if __name__ == '__main__':
 	mic_path = sys.argv[1]
 	main(mic_path)

--- a/src/icebreaker/five_figures.py
+++ b/src/icebreaker/five_figures.py
@@ -6,37 +6,28 @@ import mrcfile
 import cv2
 import os
 import seaborn as sns
+from pathlib import Path
 
 
 def main(mic_path):
-	orig_stdout = sys.stdout
 	indir = mic_path
 	with open('five_figs_test.csv','w') as f:
-		files = []
-		for filename in os.listdir(indir):
-			if (filename.endswith(".mrc")):
-				finalpath = os.path.join(indir, filename)
-				files.append(finalpath)
-			else:
-				continue
-		# files = files.sort()
-		files = sorted(files)
-		vector_data = []
+		files = [Path(indir / filename) for filename in Path(indir).glob('**/*') if filename.suffix == '.mrc']
 		r = 10000
 
-		f.write('path,min,q1,q2=median,q3,max')
-		for img_path in files:
+		f.write("path,min,q1,q2=median,q3,max\n")
+		for img_path in sorted(files):
 			with mrcfile.open(img_path, 'r', permissive=True) as mrc:
 				img = mrc.data
-				if (np.isnan(np.sum(img))):
-					continue
-				else:
-					data_line = img_path[:-4] + ',', str(int(np.min(img) * r)) + ',', str(int(np.quantile(img, 0.25) * r)) + ',',
-					str(int(np.median(img) * r)) + ',', str(int(np.quantile(img, 0.75) * r)) + ',',
-					int(np.max(img) * r)
-					f.write(data_line)
-	f.close()
-		
+				if not np.isnan(np.sum(img)):
+					path = img_path[:-4]
+					min = int(np.min(img) * r)
+					q1 = int(np.quantile(img, 0.25) * r)
+					median = int(np.median(img) * r)
+					q3 = int(np.quantile(img, 0.75) * r)
+					max = int(np.max(img) * r)
+					f.write(f"{path},{min},{q1},{median},{q3},{max}")
+
 if __name__ == '__main__':
 	mic_path = sys.argv[1]
 	main(mic_path)

--- a/src/icebreaker/five_figures.py
+++ b/src/icebreaker/five_figures.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 import mrcfile
 import cv2
-import os
 import seaborn as sns
 from pathlib import Path
 


### PR DESCRIPTION
Minor changes to the five-figure script/wrapper.
1. Remove spaces between column titles in .csv file. This makes it easier to parse.
2. Use file.write() rather than print() statements.
3. Keep micrograph names whole. This shouldn't cause any problems but makes it easier to match the micrographs up with other stages in the pipeline.