### PR TITLE
Correctly collect the names of previously processed micrographs

### DIFF
--- a/src/icebreaker/cli/ib_5fig.py
+++ b/src/icebreaker/cli/ib_5fig.py
@@ -63,9 +63,9 @@ def run_job(project_dir, job_dir, args_list, cpus):
     with open(
         "done_mics.txt", "a+"
     ) as f:  # Done mics is to ensure that IB doesn't pick from already done mics
-        for micrograph in os.listdir("IB_input"):
-            if micrograph.endswith("mrc"):
-                f.write(micrograph + "\n")
+        for micrograph in pathlib.Path("./IB_input").glob("**/*"):
+            if micrograph.suffix == ".mrc":
+                f.write(micrograph.name + "\n")
 
     # Required star file
     out_doc = gemmi.cif.Document()

--- a/src/icebreaker/cli/ib_5fig.py
+++ b/src/icebreaker/cli/ib_5fig.py
@@ -57,7 +57,9 @@ def run_job(project_dir, job_dir, args_list, cpus):
                 os.path.join("IB_input", *list(micpath.parts[2:])),
             )
 
-    five_figures.main(pathlib.Path(project_dir) / job_dir / "IB_input", cpus)
+    five_figures.main(
+        pathlib.Path(project_dir) / job_dir / "IB_input", cpus, append=True
+    )
     print("Done five figures")
 
     with open(

--- a/src/icebreaker/five_figures.py
+++ b/src/icebreaker/five_figures.py
@@ -23,7 +23,7 @@ def _process_mrc(img_path: str, csv_lines: list, lock: Lock, r: int) -> None:
     return None
 
 
-def main(grouped_mic_dir: str, cpus: int = 1) -> None:
+def main(grouped_mic_dir: str, cpus: int = 1, append: bool = False) -> None:
     manager = Manager()
     lock = manager.Lock()
     files = [str(filename) for filename in Path(grouped_mic_dir).glob("**/*.mrc")]
@@ -32,10 +32,15 @@ def main(grouped_mic_dir: str, cpus: int = 1) -> None:
     csv_lines = manager.list()
     with Pool(cpus) as p:
         p.starmap(_process_mrc, [(fl, csv_lines, lock, r) for fl in sorted(files)])
-    with open("five_figs_test.csv", "w") as f:
-        f.write("path,min,q1,q2=median,q3,max\n")
-        for line in csv_lines:
-            f.write(line)
+    if append and Path("five_figs_test.csv").is_file():
+        with open("five_figs_test.csv", "a+") as f:
+            for line in csv_lines:
+                f.write(line)
+    else:
+        with open("five_figs_test.csv", "w") as f:
+            f.write("path,min,q1,q2=median,q3,max\n")
+            for line in csv_lines:
+                f.write(line)
     return None
 
 


### PR DESCRIPTION
The directory structure of `IB_input` has changed and is now more complicated. The gathering of processed micrograph names was therefore not working. Also add the functionality to append these names to the `done_mics.txt` file to stop overwriting previously registered names.